### PR TITLE
Fix timed transition

### DIFF
--- a/FHEM/33_stateMachine.pm
+++ b/FHEM/33_stateMachine.pm
@@ -204,7 +204,7 @@ stateMachine_doTransition($$%)
     if( my $t = getEmptyTransition($transitions->{$new_state}) ) {
       my $timeout = $t->{timeout};
       $hash->{helper}{timed} = { t => $t, specials => $specials };
-      InternalTimer( gettimeofday()+$timeout, "stateMachine_retrigger", $hash, 0 );
+      InternalTimer( gettimeofday()+$timeout, "stateMachine_timedTransition", $hash, 0 );
     }
 
   } elsif( defined($new_state) ) {


### PR DESCRIPTION
This fixes the timed transition.

If you set a transition without an event but a timeout, the state will be changed after timeout.

Example:
{ timeout => 10, action => 'set something OFF', newState => 'OFF' }, \
